### PR TITLE
null / empty check OPENNMS_HOME and lazily fall back to `/opt/opennms`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.tools</groupId>
     <artifactId>brannock</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
     <name>OpenNMS Features Brannock</name>
     <packaging>bundle</packaging>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.tools</groupId>
     <artifactId>brannock</artifactId>
-    <version>1.0</version>
+    <version>1.2-SNAPSHOT</version>
     <name>OpenNMS Features Brannock</name>
     <packaging>bundle</packaging>
     <build>

--- a/src/main/java/org/opennms/netmgt/brannock/Brannock.java
+++ b/src/main/java/org/opennms/netmgt/brannock/Brannock.java
@@ -214,7 +214,11 @@ public class Brannock implements BundleActivator {
     }
     
     private void writeData(String data) throws IOException {
-        String fileName = System.getenv("OPENNMS_HOME") + "/logs/brannock_stats.json";
+        String onmsHome = System.getenv("OPENNMS_HOME");
+        if (onmsHome == null || "".equals(onmsHome) ) {
+            onmsHome = "/opt/opennms"; // TODO: debian exists
+        }
+        String fileName = onmsHome + "/logs/brannock_stats.json";
         File file = new File(fileName);
         if (!file.exists()) {
             file.createNewFile();


### PR DESCRIPTION
I also version bumped since you didn't prior to 1.1